### PR TITLE
feat: use groq faster with instructor

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -51,15 +51,17 @@ def create_client():
             print("Falling back to Groq...")
             # Fall back to Groq
     
+    # Initialize with API key
+    client = Groq(api_key=os.getenv("GROQ_API_KEY"))
+
     # Default to Groq
-    client = instructor.from_provider(
-        "groq/llama-3.3-70b-versatile", 
-        api_key=os.getenv("GROQ_API_KEY")
+    client = instructor.from_groq(
+        client
     )
     return {
         "instructor": client,
         "native": None,
-        "model": "llama-3.3-70b-versatile",
+        "model": "openai/gpt-oss-120b",
         "provider": "groq"
     }
 
@@ -221,7 +223,7 @@ OTHER ACTIONS:
 - SHORT_REPLY: Just notify user with a message. Their clipboard remains unchanged.
 
 Use the current date/time to understand when things happened relative to now. Only respond with valid JSON matching the AssistantResponse schema.
-
+If the user asks you to convert data formats, DO IT IN FULL DO NOT TRUNCATE ANYTHING. THERE IS NO CHARACTER LIMIT FOR COPIED CONTENT.
 Remember that you are primariy interacting via short messages and by assisting the user with their clipboard content. There might be some noisey text from the voice recognition, so focus on the core intent of the command.
 """,
                 },


### PR DESCRIPTION
### TL;DR

Updated the Groq client initialization and switched the default model to "openai/gpt-oss-120b".

### What changed?

- Modified the client initialization process in `create_client()` to first create a native Groq client with the API key, then wrap it with instructor
- Changed the model from "llama-3.3-70b-versatile" to "openai/gpt-oss-120b"
- Added an instruction to the system prompt that emphasizes not truncating data when converting formats

### How to test?

1. Ensure the GROQ_API_KEY environment variable is set
2. Run the application and verify it connects to Groq successfully
3. Test data format conversion commands to ensure they don't truncate content

### Why make this change?

The updated client initialization provides better compatibility with the Groq API. Switching to the "openai/gpt-oss-120b" model likely offers improved performance or capabilities. The added instruction about not truncating data when converting formats addresses a potential issue where the assistant might cut off content during format conversions.