### PR TITLE
chore: slight prompt change

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -112,7 +112,7 @@ class BaseAssistantResponse(BaseModel):
     )
     emoji: Optional[str] = Field(
         None,
-        description="An optional emotion based on the message. The options are angry, annoyed, excited, happy, love, sad, surprised, thinking, winking. Always use an emoji that matches the tone of the message.",
+        description="An optional emotion based on the message. The options are angry, annoyed, excited, happy, love, sad, surprised, thinking, winking. Always pick an emoji, try to match the tone of the message.",
     )
     content_for_clipboard: Optional[str] = None
     meme_top_text: Optional[str] = Field(None, description="Top text for the meme")


### PR DESCRIPTION
### TL;DR

Updated the emoji field description in the AssistantResponse model to encourage always selecting an emoji.

### What changed?

Modified the description for the `emoji` field in the `AssistantResponse` class:
- Changed from "Always use an emoji that matches the tone of the message" to "Always pick an emoji, try to match the tone of the message"
- This subtle change emphasizes that an emoji should always be selected, while still encouraging tone matching

### How to test?

1. Check that the model properly responds with emojis in all responses
2. Verify that the emojis generally match the tone of the message content
3. Confirm that responses rarely or never omit emojis

### Why make this change?

The previous description may have been interpreted as "only use an emoji if it matches the tone," leading to cases where no emoji was selected. This change clarifies that an emoji should always be included, with tone matching as a secondary consideration.